### PR TITLE
Hook airkit/dagre into our deployment pipeline and Artifactory

### DIFF
--- a/buildspec.yml
+++ b/buildspec.yml
@@ -1,0 +1,26 @@
+version: 0.2
+
+env:
+  variables:
+    ARTIFACTORY_USER: "ci-bot"
+  parameter-store:
+    ARTIFACTORY_TOKEN: "ci_jfrog_password"
+    GITHUB_TOKEN: "git-token"
+    NPM_REGISTRY_TOKEN: "ci_jfrog_npm_token"
+phases:
+  install:
+    commands:
+      - git config --global user.email "bot@ruist.com"
+      - git config --global user.name "Bot Builder"
+      - eval `ssh-agent -s`
+  build:
+    commands:
+      - echo Build started on `date`
+      - ru_build --build-environment CODEBUILD NODE_LIBRARY $BUILD_TYPE
+      - echo Build completed on `date`
+artifacts:
+  files:
+    - '**/*'
+cache:
+  paths:
+    - '/root/.npm/**/*'

--- a/infra/main.tf
+++ b/infra/main.tf
@@ -1,0 +1,42 @@
+variable "name" {}
+variable "env" {}
+variable "profile" {}
+variable "git_organization" {}
+variable "git_repo" {}
+variable "git_branch" {}
+variable "github_token" {}
+variable "aws_region" {}
+variable "aws_main_az" {}
+variable "aws_account_id" {}
+
+terraform {
+  backend "s3" {
+    bucket = "ruist-dev"
+    workspace_key_prefix = "tf_state"
+    region = "us-west-2"
+    key = "state"
+    encrypt = true
+    dynamodb_table = "TerraformStates"
+  }
+}
+
+module "build-pipeline" {
+  source = "git::git@github.com:Ruist/infra-codebuild.git"
+
+  env = "${var.env}"
+  profile = "${var.profile}"
+  aws_region = "${var.aws_region}"
+  aws_account_id = "${var.aws_account_id}"
+  aws_availability_zone = "${var.aws_main_az}"
+  project_name = "${var.name}"
+  git_organization = "${var.git_organization}"
+  git_repo = "${var.git_repo}"
+  git_branch = "${var.git_branch}"
+  github_token = "${var.github_token}"
+  deploy_docker = "false"
+  image = "${var.aws_account_id}.dkr.ecr.${var.aws_region}.amazonaws.com/node-dind-${var.aws_region}:latest"
+}
+
+output "artifact_bucket_name" {
+  value = "${module.build-pipeline.artifact_bucket_name}"
+}

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -58,11 +58,11 @@ module.exports = function(config) {
 
     // start these browsers
     // available browser launchers: https://npmjs.org/browse/keyword/karma-launcher
-    browsers: ['Chrome', 'Firefox', 'PhantomJS'],
+    browsers: ['ChromeHeadless', 'Firefox', 'PhantomJS'],
 
 
     // Continuous Integration mode
     // if true, Karma captures browsers, runs the tests and exits
-    singleRun: false
+    singleRun: false,
   });
 };

--- a/karma.core.conf.js
+++ b/karma.core.conf.js
@@ -60,7 +60,7 @@ module.exports = function(config) {
 
     // start these browsers
     // available browser launchers: https://npmjs.org/browse/keyword/karma-launcher
-    browsers: ['Chrome', 'Firefox', 'PhantomJS'],
+    browsers: ['ChromeHeadless', 'Firefox', 'PhantomJS'],
 
 
     // Continuous Integration mode

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "dagre",
+  "name": "@ruist/dagre",
   "version": "0.8.6-pre",
   "lockfileVersion": 1,
   "requires": true,

--- a/package.json
+++ b/package.json
@@ -1,11 +1,15 @@
 {
-  "name": "dagre",
+  "name": "@ruist/dagre",
   "version": "0.8.6-pre",
   "description": "Graph layout for JavaScript",
   "author": "Chris Pettitt <cpettitt@gmail.com>",
   "contributors": [
     "Matthew Dahl (https://github.com/sandersky)"
   ],
+  "scripts": {
+    "build": "make dist",
+    "clean": "make clean"
+  },
   "license": "MIT",
   "main": "index.js",
   "keywords": [


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change and which issue is fixed. Please provide the motivation for why this change is necessary. -->

This PR makes a series of changes to the repository so that it's part of our Codebuild pipeline and publish into Artifactory as a private `@ruist/*` package.

### Changes

- Update package name to `@ruist/dagre` to match our private package registry prefix.
- Add `build` and `clean` scripts to `package.json` (uses existing Makefile commands)
- Switch to `ChromeHeadless` when running tests (might need to tweak a bit more depending on how Codebuild works)
- Add `buildspec.yml` and `infra/main.tf` config files

### Todo Later

- Hook unit testing into `nyc` to report code coverage
- Add Sonar (not sure if it will apply because this project uses a wildly different style, and also... uses plain JS)

Fixes Issue # (ex. RU-123)

## Risk Assessment
<!-- What are the risks? Is there a business impact? -->

No known risks or business impact.

## Performance Impact
<!-- Please describe any relevant performance impact of this change. This can be positive or negative impact. -->

<!-- How did you characterize/test the performance impact? -->

No known or significant performance impact. 

## Testing Assessment
<!-- Please describe what testing has been done. -->

- [x] Unit Tests
- [x] Integration Tests

## Security Assessment
<!-- Please verify that the change does not introduce any of the following security issues. -->

- [x] Injection Flaws
- [x] Buffer overflows
- [x] Insecure Cryptographic Storage
- [x] Insecure Communications
- [x] Improper Error Handling
- [x] XSS
- [x] Improper Access Control
- [x] CSRF


<!-- this file in in repo: .github/pull_request_temaplate.md and is an org-wide default. You can override each repo with a local file -->
